### PR TITLE
Fix for help buttons not working sometimes

### DIFF
--- a/src/buttons/help_.button.ts
+++ b/src/buttons/help_.button.ts
@@ -5,7 +5,7 @@ export default class Activitie extends Button {
     constructor(client: Client) {
         super({
             name: "help_",
-            regex: /help_(es|en)_.+/gi,
+            regex: /help_(es|en)_.+/i,
         });
     }
 


### PR DESCRIPTION
This should fix the problem that ocurred that made the buttons in >help work once, then not, then work again, then not, etc.